### PR TITLE
Two sampler scheme

### DIFF
--- a/selection/algorithms/covtest.py
+++ b/selection/algorithms/covtest.py
@@ -11,7 +11,7 @@ The covariance test itself is asymptotically exponential
 Both tests mentioned above require knowledge 
 (or a good estimate) of sigma, the noise variance.
 
-This module also includes a second exact test called `reduced_covtest`_
+This module also includes a second exact test called `selected_covtest`_
 that can use sigma but does not need it.
 
 .. _covTest: http://arxiv.org/abs/1301.7161
@@ -24,9 +24,9 @@ that can use sigma but does not need it.
 import numpy as np
 from scipy.special import ndtr, ndtri
 
-from .constraints.affine import constraints, sample_from_constraints, gibbs_test
+from ..constraints.affine import constraints, sample_from_constraints, gibbs_test
 from .forward_step import forward_stepwise
-from .discrete_family import discrete_family
+from ..distributions.discrete_family import discrete_family
 
 def covtest(X, Y, sigma=1, exact=True,
             covariance=None):
@@ -54,6 +54,9 @@ def covtest(X, Y, sigma=1, exact=True,
         If True, use the first spacings test, else use
         the exponential approximation.
 
+    covariance : np.array (optional)
+        If None, defaults to identity.
+
     Returns
     -------
 
@@ -72,6 +75,9 @@ def covtest(X, Y, sigma=1, exact=True,
 
     """
     n, p = X.shape
+
+    if covariance is None:
+        covariance = np.identity(n)
 
     Z = np.dot(X.T, Y)
     idx = np.argsort(np.fabs(Z))[-1]
@@ -93,7 +99,7 @@ def covtest(X, Y, sigma=1, exact=True,
         exp_pvalue = np.exp(-L1 * (L1-L2) / S**2) # upper bound is ignored
         return con, exp_pvalue, idx, sign
 
-def reduced_covtest(X, Y, ndraw=5000, burnin=2000, sigma=None,
+def selected_covtest(X, Y, ndraw=5000, burnin=2000, sigma=None,
                     covariance=None):
     """
     An exact test that is more

--- a/selection/algorithms/lasso.py
+++ b/selection/algorithms/lasso.py
@@ -413,7 +413,8 @@ def data_carving(y, X,
                  ndraw=8000,
                  burnin=2000,
                  splitting=False,
-                 compute_intervals=True):
+                 compute_intervals=True,
+                 UMPU=False):
 
     """
     Fit a LASSO with a default choice of Lagrange parameter
@@ -458,6 +459,11 @@ def data_carving(y, X,
     splitting : bool (optional)
         If True, also return splitting pvalues and intervals.
 
+    compute_intervals : bool (optional)
+        Compute selective intervals?
+
+    UMPU : bool (optional)
+        Perform the UMPU test?
       
     Returns
     -------
@@ -593,7 +599,7 @@ def data_carving(y, X,
 
             con_cp = copy(con)
             conditional_law = con_cp.conditional(conditional_linear[keep], \
-                                                     np.dot(X_E.T, y)[keep])
+                                                 np.dot(X_E.T, y)[keep])
             
             # tilt so that samples are closer to observed values
             # the multiplier should be the pseudoMLE so that
@@ -628,7 +634,8 @@ def data_carving(y, X,
                                              white=False,
                                              ndraw=ndraw,
                                              burnin=burnin,
-                                             how_often=10)
+                                             how_often=10,
+                                             UMPU=UMPU)
 
                 intervals.append((np.nan, np.nan))
 

--- a/selection/algorithms/lasso.py
+++ b/selection/algorithms/lasso.py
@@ -639,6 +639,7 @@ def data_carving(y, X,
                                              burnin=burnin,
                                              how_often=10,
                                              UMPU=UMPU)
+                intervals.append((np.nan, np.nan))
 
             pval = family.cdf(0, observed)
             pval = 2 * min(pval, 1 - pval)

--- a/selection/algorithms/lasso.py
+++ b/selection/algorithms/lasso.py
@@ -42,6 +42,10 @@ def instance(n=100, p=200, s=7, sigma=5, rho=0.3, snr=7,
     Design is equi-correlated in the population,
     normalized to have columns of norm 1.
 
+    For the default settings, a $\lambda$ of around 13.5
+    corresponds to the theoretical $E(\|X^T\epsilon\|_{\infty})$
+    with $\epsilon \sim N(0, \sigma^2 I)$.
+
     Parameters
     ----------
 

--- a/selection/algorithms/tests/test_covtest.py
+++ b/selection/algorithms/tests/test_covtest.py
@@ -28,19 +28,37 @@ def test_covtest():
 def test_tilting(nsim=100):
 
     P = []
-    for _ in range(nsim):
-        X, Y, beta, active, sigma = instance()
+    covered0 = 0
+    coveredA = 0
+    screen = 0
+
+    for i in range(nsim):
+        X, Y, beta, active, sigma = instance(n=20, p=30)
+
         Y0 = np.random.standard_normal(X.shape[0]) * sigma
+
+        # null pvalues and intervals
+
         cone, pvalue, idx, sign = selected_covtest(X, Y0, sigma=sigma)
-        p1 = gibbs_test(cone, Y0, X[:,idx] * sign,
-                        ndraw=25000,
-                        burnin=1000,
-                        alternative='greater',
-                        sigma_known=True)[0]
+        p1, _, _, fam = gibbs_test(cone, Y0, X[:,idx] * sign,
+                                   ndraw=15000,
+                                   burnin=10000,
+                                   alternative='greater',
+                                   sigma_known=True)
+
+        eta = X[:,idx] * sign
+        observed_value = (Y0 * eta).sum()
+        lower_lim, upper_lim = fam.equal_tailed_interval(observed_value)
+        lower_lim_final = np.dot(eta, np.dot(cone.covariance, eta)) * lower_lim
+        upper_lim_final = np.dot(eta, np.dot(cone.covariance, eta)) * upper_lim
+        covered0 += (lower_lim_final < 0) * (upper_lim_final > 0)
+        print covered0 / (i + 1.), 'coverage0'
+
+        # compare to no tilting
 
         p2 = gibbs_test(cone, Y0, X[:,idx] * sign,
-                        ndraw=25000,
-                        burnin=1000,
+                        ndraw=15000,
+                        burnin=10000,
                         alternative='greater',
                         sigma_known=True,
                         do_tilt=False)[0]
@@ -48,10 +66,48 @@ def test_tilting(nsim=100):
         Pa = np.array(P)
 
         # p1 and p2 should be very close, so have high correlation
-        print np.corrcoef(Pa.T)[0,1]
+        print np.corrcoef(Pa.T)[0,1], 'correlation'
 
         # they should also look uniform -- mean should be about 0.5, sd about 0.29
 
-        print np.mean(Pa, 0), np.std(Pa, 0)
+        print np.mean(Pa, 0), 'mean of nulls'
+        print np.std(Pa, 0), 'sd of nulls'
+
+        # alternative intervals
+
+        mu = 3 * X[:,0] * sigma
+        YA = np.random.standard_normal(X.shape[0]) * sigma + mu 
+
+        cone, pvalue, idx, sign = selected_covtest(X, YA, sigma=sigma)
+        _, _, _, fam = gibbs_test(cone, YA, X[:,idx] * sign,
+                                   ndraw=15000,
+                                   burnin=10000,
+                                   alternative='greater',
+                                   sigma_known=True)
+
+        if idx == 0:
+            screen += 1
+
+            eta = X[:,0] * sign
+            observed_value = (YA * eta).sum()
+            target = (eta * mu).sum()
+            lower_lim, upper_lim = fam.equal_tailed_interval(observed_value)
+            lower_lim_final = np.dot(eta, np.dot(cone.covariance, eta)) * lower_lim
+            upper_lim_final = np.dot(eta, np.dot(cone.covariance, eta)) * upper_lim
+            print lower_lim_final, upper_lim_final, target
+            coveredA += (lower_lim_final < target) * (upper_lim_final > target)
+            print coveredA / (screen * 1.), 'coverageA'
+
+        print screen / (i + 1.), 'screening'
+
     plt.figure()
     plt.scatter(Pa[:,0], Pa[:,1])
+
+    try:
+        import statsmodels.api as sm
+        plt.figure()
+        G = np.linspace(0, 1, 101)
+        plt.plot(G, sm.distributions.ECDF(Pa[:,0])(G))
+        plt.plot(G, sm.distributions.ECDF(Pa[:,1])(G))
+    except ImportError: # no statsmodels
+        pass

--- a/selection/algorithms/tests/test_covtest.py
+++ b/selection/algorithms/tests/test_covtest.py
@@ -1,6 +1,11 @@
 import numpy as np
 import itertools
-from selection.covtest import covtest, reduced_covtest
+import numpy.testing.decorators as dec
+from matplotlib import pyplot as plt
+
+from selection.algorithms.lasso import instance, lasso
+from selection.algorithms.covtest import covtest, selected_covtest
+from selection.constraints.affine import gibbs_test
 
 def test_covtest():
 
@@ -14,7 +19,39 @@ def test_covtest():
         con, pval, idx, sign = covtest(X, Y, sigma=1.5, exact=exact,
                                        covariance=covariance)
     for covariance in [None, np.identity(n)]:
-        con, pval, idx, sign = reduced_covtest(X, Y, sigma=1.5,
-                                               covariance=covariance)
+        con, pval, idx, sign = selected_covtest(X, Y, sigma=1.5,
+                                                covariance=covariance)
 
     return pval
+
+@dec.slow
+def test_tilting(nsim=100):
+
+    P = []
+    for _ in range(nsim):
+        X, Y, beta, active, sigma = instance()
+        Y0 = np.random.standard_normal(X.shape[0]) * sigma
+        cone, pvalue, idx, sign = selected_covtest(X, Y0, sigma=sigma)
+        p1 = gibbs_test(cone, Y0, X[:,idx] * sign,
+                        ndraw=25000,
+                        burnin=1000,
+                        alternative='greater',
+                        sigma_known=True)[0]
+
+        p2 = gibbs_test(cone, Y0, X[:,idx] * sign,
+                        ndraw=25000,
+                        burnin=1000,
+                        alternative='greater',
+                        sigma_known=True,
+                        do_tilt=False)[0]
+        P.append((p1, p2))
+        Pa = np.array(P)
+
+        # p1 and p2 should be very close, so have high correlation
+        print np.corrcoef(Pa.T)[0,1]
+
+        # they should also look uniform -- mean should be about 0.5, sd about 0.29
+
+        print np.mean(Pa, 0), np.std(Pa, 0)
+    plt.figure()
+    plt.scatter(Pa[:,0], Pa[:,1])

--- a/selection/algorithms/tests/test_covtest.py
+++ b/selection/algorithms/tests/test_covtest.py
@@ -40,13 +40,14 @@ def test_tilting(nsim=100):
         # null pvalues and intervals
 
         cone, pvalue, idx, sign = selected_covtest(X, Y0, sigma=sigma)
-        p1, _, _, fam = gibbs_test(cone, Y0, X[:,idx] * sign,
-                                   ndraw=15000,
+        eta = X[:,idx] * sign
+        p1, _, _, fam = gibbs_test(cone, Y0, eta, 
+                                   ndraw=50000,
                                    burnin=10000,
                                    alternative='greater',
-                                   sigma_known=True)
+                                   sigma_known=True,
+                                   tilt=eta)
 
-        eta = X[:,idx] * sign
         observed_value = (Y0 * eta).sum()
         lower_lim, upper_lim = fam.equal_tailed_interval(observed_value)
         lower_lim_final = np.dot(eta, np.dot(cone.covariance, eta)) * lower_lim
@@ -57,11 +58,11 @@ def test_tilting(nsim=100):
         # compare to no tilting
 
         p2 = gibbs_test(cone, Y0, X[:,idx] * sign,
-                        ndraw=15000,
+                        ndraw=50000,
                         burnin=10000,
                         alternative='greater',
                         sigma_known=True,
-                        do_tilt=False)[0]
+                        tilt=None)[0]
         P.append((p1, p2))
         Pa = np.array(P)
 
@@ -80,10 +81,11 @@ def test_tilting(nsim=100):
 
         cone, pvalue, idx, sign = selected_covtest(X, YA, sigma=sigma)
         _, _, _, fam = gibbs_test(cone, YA, X[:,idx] * sign,
-                                   ndraw=15000,
-                                   burnin=10000,
-                                   alternative='greater',
-                                   sigma_known=True)
+                                  ndraw=15000,
+                                  burnin=10000,
+                                  alternative='greater',
+                                  sigma_known=True,
+                                  tilt=eta)
 
         if idx == 0:
             screen += 1

--- a/selection/algorithms/tests/test_sqrt_lasso.py
+++ b/selection/algorithms/tests/test_sqrt_lasso.py
@@ -222,7 +222,8 @@ def test_data_carving(n=100,
                       df=np.inf,
                       coverage=0.90,
                       sigma=3,
-                      fit_args={'min_its':120, 'tol':1.e-12}):
+                      fit_args={'min_its':120, 'tol':1.e-12},
+                      compute_intervals=True):
 
     counter = 0
 
@@ -250,7 +251,8 @@ def test_data_carving(n=100,
                                       ndraw=ndraw,
                                       burnin=burnin,
                                       coverage=coverage,
-                                      fit_args=fit_args)
+                                      fit_args=fit_args,
+                                      compute_intervals=compute_intervals)
 
             carve = [r[1] for r in results]
             split = [r[3] for r in results]

--- a/selection/constraints/base.py
+++ b/selection/constraints/base.py
@@ -140,14 +140,6 @@ class constraint(object):
         x = np.linalg.norm(np.dot(X_s.T, y))
         return distr.sf(x)
 
-    
-
-
-
-
-
-
-
 class cons_op(constraint):
 
     def __init__(self):

--- a/selection/constraints/optimal_tilt.py
+++ b/selection/constraints/optimal_tilt.py
@@ -1,0 +1,89 @@
+import numpy as np
+import regreg.api as rr
+
+class optimal_tilt(rr.smooth_atom):
+
+    """
+    An objective used to find an
+    approximately best tilt for a
+    given affine constraint and a given
+    direction of interest.
+
+    We approximately solve the problem
+    
+    ..math::
+
+        \text{min.}_{c,z:A(z + c\eta + \gamma) \leq b} \|z + c \eta\|^2_{\Sigma}
+
+    where the objective is Mahalanobis distance
+    for the constraint's covariance, $\gamma$ is
+    the constraint's mean and the set
+    $\{w:Aw \leq b\}$ is the affine constraint.
+
+    """
+
+    def __init__(self, affine_con, 
+                 direction_of_interest,
+                 offset=None,
+                 quadratic=None,
+                 initial=None):
+
+        rr.smooth_atom.__init__(self,
+                                affine_con.linear_part.shape[1] + 1,
+                                offset=offset,
+                                quadratic=quadratic,
+                                initial=initial)
+
+        self.affine_con = affine_con
+        self.direction_of_interest = eta = direction_of_interest 
+
+        design = self.design = np.hstack([np.identity(affine_con.dim), 
+                                          eta.reshape((-1,1))])
+
+        sqrt_inv = affine_con.covariance_factors()[1]
+        Si = np.dot(sqrt_inv.T, sqrt_inv)
+        self.Q = np.dot(design.T, np.dot(Si, design))
+
+        gamma = affine_con.mean
+
+        linear_part = np.dot(affine_con.linear_part, design)
+        offset = affine_con.offset - np.dot(affine_con.linear_part, 
+                                            affine_con.mean)
+
+        scaling = np.sqrt((linear_part**2).sum(1))
+        linear_part /= scaling[:,None]
+        offset /= scaling
+
+        self.linear_objective = 0.
+
+        smoothing_quadratic = rr.identity_quadratic(1.e-2, 0, 0, 0)
+        self.smooth_constraint = rr.nonpositive.affine(linear_part,
+                                 -offset).smoothed(
+                                 smoothing_quadratic)
+
+    def smooth_objective(self, z, mode='both', check_feasibility=False):
+
+        Qz = np.dot(self.Q, z) 
+
+        if mode == 'both':
+            fc, gc = self.smooth_constraint.smooth_objective(z, mode='both')
+            g = Qz + self.linear_objective + gc
+            f = (z*Qz).sum() * 0.5 + (self.linear_objective*z).sum() + fc
+            return f, g
+        elif mode == 'grad':
+            gc = self.smooth_constraint.smooth_objective(z, mode='grad')
+            g = Qz + self.linear_objective + gc
+            return g
+        elif mode == 'func':
+            fc = self.smooth_constraint.smooth_objective(z, mode='func')
+            f = (z*Qz).sum() * 0.5 + (self.linear_objective*z).sum() + fc
+            return f
+
+    def fit(self, **regreg_args):
+        soln = self.soln = self.solve(**regreg_args)
+        self.z_soln = soln[:-1]
+        self.c_soln = soln[-1]
+        self.optimal_point = np.dot(self.design, self.soln)
+        self.reweight_func = -self.affine_con.solve(self.optimal_point)
+        return self.optimal_point
+

--- a/selection/constraints/tests/test_affine.py
+++ b/selection/constraints/tests/test_affine.py
@@ -8,6 +8,7 @@ from scipy.stats import chi
 import nose.tools as nt
 
 import selection.affine as AC
+from selection.optimal_tilt import optimal_tilt
 
 def test_conditional():
 
@@ -143,5 +144,30 @@ def test_sampling():
     nt.assert_true(np.linalg.norm(V.mean(0)-C.mean) < 0.01)
     nt.assert_true(np.linalg.norm(np.einsum('ij,ik->ijk', V, V).mean(0) - 
                                   np.outer(V.mean(0), V.mean(0)) - S) < 0.01)
+
+def test_optimal_tilt():
+
+    A = np.vstack(-np.identity(4))
+    b = -np.array([1,2,3,4.])
+    con = constraints(A, b, covariance=2 * np.identity(4),
+                     mean=np.array([3,-4.3,-2.2,1.2]))
+    eta = np.array([1,0,0,0.])
+
+    tilt = optimal_tilt(con, eta)
+    print tilt.smooth_objective(np.zeros(5), mode='both')
+    opt_tilt = tilt.fit(max_its=20)
+    print con.mean + opt_tilt
+
+    A = np.vstack([-np.identity(4),
+                    np.identity(4)])
+    b = np.array([-1,-2,-3,-4.,3,4,5,11])
+    con = constraints(A, b, covariance=2 * np.identity(4),
+                     mean=np.array([3,-4.3,12.2,20.2]))
+    eta = np.array([1,0,0,0.])
+
+    tilt = optimal_tilt(con, eta)
+    print tilt.smooth_objective(np.zeros(5), mode='both')
+    opt_tilt = tilt.fit(max_its=20)
+    print con.mean + opt_tilt
 
 # nose.run()


### PR DESCRIPTION
Tried to stabilize tilting when intervals are to be formed. Procedure is now a two-step procedure: one a deterministic optimization, the second a one-parameter MLE.

When accept-reject is easy, the sampler will just use accept-reject.
